### PR TITLE
Fix dockerfile

### DIFF
--- a/.codeocean/environment.json
+++ b/.codeocean/environment.json
@@ -1,0 +1,9 @@
+{
+    "version": 1,
+    "base_image": "codeocean/jupyterlab:3.6.1-miniconda4.12.0-python3.9-ubuntu20.04",
+    "options": {
+        "registry_host_arg": true,
+        "git_ask_pass": true,
+        "mount_secrets": true
+    }
+}

--- a/.codeocean/environment.json
+++ b/.codeocean/environment.json
@@ -1,9 +1,9 @@
 {
-    "version": 1,
-    "base_image": "codeocean/jupyterlab:3.6.1-miniconda4.12.0-python3.9-ubuntu20.04",
-    "options": {
-        "registry_host_arg": true,
-        "git_ask_pass": true,
-        "mount_secrets": true
-    }
+	"version": 1,
+	"base_image": "codeocean/jupyterlab:3.6.1-miniconda4.12.0-python3.9-ubuntu20.04",
+	"options": {
+		"registry_host_arg": true,
+		"git_ask_pass": true,
+		"mount_secrets": true
+	}
 }

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -1,9 +1,7 @@
-# hash:sha256:6ceefde681fb5ad2ca41bca5b1ebdfc35ce9ce0f7acc50dc183706cc463f5d61
+# hash:sha256:07578976d577fe0192fb714e4ff5ebe896c4c5131c39381abc60e09860246b40
 ARG REGISTRY_HOST
 FROM $REGISTRY_HOST/codeocean/jupyterlab:3.6.1-miniconda4.12.0-python3.9-ubuntu20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
-
-ARG GIT_ASK_PASS
-ARG GIT_ACCESS_TOKEN
+ARG GIT_ASKPASS
 COPY git-ask-pass /

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -4,6 +4,6 @@ FROM $REGISTRY_HOST/codeocean/jupyterlab:3.6.1-miniconda4.12.0-python3.9-ubuntu2
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-ARG GIT_ASKPASS
+ARG GIT_ASK_PASS
 ARG GIT_ACCESS_TOKEN
-COPY git-askpass /
+COPY git-ask-pass /


### PR DESCRIPTION
Updates the dockerfile and adds an environment.json (which avoids having it auto-create, necessitating a commit)

See this teams thread: https://teams.microsoft.com/l/message/19:QOzecEtJ3XBDmm0WCxZzSAcm34SEdXDrYUn0LojLtqw1@thread.tacv2/1773088416548?tenantId=32669cd6-737f-4b39-8bdd-d6951120d3fc&groupId=5a91c6a5-3e76-47c1-9bba-32d9f1bca4f5&parentMessageId=1773088416548&teamName=Code%20Ocean&channelName=General

I initially got this error when trying to launch a command terminal in the CO UI after creating the capsule from the template:

```

[31mfailed to compute cache key: failed to calculate checksum of ref 19eab222-df85-4435-986a-3fb0f18ba420::grqddvcqnghpnsjuamc5w12h7: "/git-askpass": not found
#1 [internal] load remote build context
#1 DONE 0.0s

#2 copy /context /
#2 DONE 0.0s

#3 [internal] load metadata for registry.codeocean.allenneuraldynamics.org/codeocean/jupyterlab:3.6.1-miniconda4.12.0-python3.9-ubuntu20.04
#3 DONE 0.0s

#4 [2/4] COPY git-askpass /
#4 ERROR: failed to calculate checksum of ref 19eab222-df85-4435-986a-3fb0f18ba420::grqddvcqnghpnsjuamc5w12h7: "/git-askpass": not found

#5 [1/4] FROM registry.codeocean.allenneuraldynamics.org/codeocean/jupyterlab:3.6.1-miniconda4.12.0-python3.9-ubuntu20.04
#5 DONE 0.0s
------
 > [2/4] COPY git-askpass /:
------
```

After the change, the terminal launched without error